### PR TITLE
feat: add flake.nix derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Visualize your most used commands
 
 Use your favorite AUR helper to install [muc-git](https://aur.archlinux.org/packages/muc-git) package (or build manually using `git` and `makepkg -si`), for example: `paru -S muc-git`
 
+#### Nix
+
+You can use the outputs provided by the `flake.nix` inside this repository to install `muc`. Either with the `overlays.default` output for your system configuration, or the package output to imperatively install it with `nix install github:nate-sys/muc` or create an ad-hoc shell with `nix shell github:nate-sys/muc`
+
 #### Other distros
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1671722432,
+        "narHash": "sha256-ojcZUekIQeOZkHHzR81st7qxX99dB1Eaaq6PU5MNeKc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "652e92b8064949a11bc193b90b74cb727f2a1405",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: {
+    overlays.default = _: prev:
+      let
+        inherit (prev.rustPlatform) buildRustPackage;
+        toml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      in
+      {
+        muc = buildRustPackage {
+          pname = "muc";
+          src = self;
+          inherit (toml.package) version;
+          cargoHash = "sha256-DJMe9LhfydV1Z3Wk8vZXZlGBe4JMbE7yqnEOvVbg4f8=";
+        };
+      };
+  } //
+  (flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ self.overlays.default ];
+      };
+      inherit (pkgs) muc;
+    in
+    {
+      packages = {
+        inherit muc;
+        default = muc;
+      };
+    }));
+}


### PR DESCRIPTION
Closes #8

The most maintenance this will require is just updating the value of `cargoHash` anytime the `Cargo.lock` or `Cargo.toml` gets modified. I could not have nix calculate the hash automatically due to the fact `aecir` is a git dependency.

I've also added a section in a README about it.