### PR TITLE
Fix prefix use

### DIFF
--- a/src/hist_file.rs
+++ b/src/hist_file.rs
@@ -32,7 +32,21 @@ pub fn get_contents(args: &Args) -> String {
 
 pub fn parse_contents(contents: String, args: &Args) -> HashMap<String, usize> {
     let separators: Vec<char> = args.separators.chars().collect();
-    let commands: Vec<&str> = contents
+    let mut only_prefix = "".to_string();
+    for line in contents.split('\n') {
+        only_prefix.push_str(match &args.prefix {
+            Some(pfx) => {
+                if line.starts_with(pfx) {
+                    &line[pfx.len()..]
+                } else {
+                    ""
+                }
+            },
+            _ => line,
+        });
+        only_prefix.push_str("\n");
+    }
+    let commands: Vec<&str> = only_prefix
         .split(&*separators)
         .filter(|x| !x.is_empty())
         .into_iter()
@@ -43,10 +57,6 @@ pub fn parse_contents(contents: String, args: &Args) -> HashMap<String, usize> {
                 }
                 ""
             })
-        })
-        .map(|command| match &args.prefix {
-            Some(pfx) if command.starts_with(pfx) => &command[0..pfx.len()],
-            _ => command,
         })
         .collect();
 


### PR DESCRIPTION
The prefix argument was not handled properly
which cause outputs from fish history to look
like that:
```
$ HISTFILE=~/.local/share/fish/fish_history ./target/debug/muc --file $HISTFILE --count 3 --prefix="- cmd: " --pretty
[▮▮▮▮▮▮▮▮▮▮] 43.42% 3623 -
[▮▮▮▮▮▮    ] 27.85% 2324 when:
[▮▮▮       ] 13.46% 1123 paths:
```

This commit makes it look like that:
```
$ HISTFILE=~/.local/share/fish/fish_history ./target/debug/muc --file $HISTFILE --count 3 --prefix="- cmd: " --pretty
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
[▮▮▮▮▮▮▮▮▮▮]  6.17% 222 cd
[▮▮▮▮▮▮▮▮  ]  5.01% 180 vim
[▮▮▮▮▮▮▮   ]  4.51% 162 ls
```

This is the desired behavior.