### PR TITLE
Add better support for ZSH and adds the regex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,15 @@ version = "0.1.0"
 source = "git+https://github.com/nate-sys/aecir?branch=main#32746009d92b6bf5fc36d138e33b5dcc46c75460"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,11 +136,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "muc"
 version = "0.1.0"
 dependencies = [
  "aecir",
  "clap",
+ "regex",
  "utf8_slice",
 ]
 
@@ -188,6 +204,23 @@ checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 clap = { version = "4.0.32", features = ["derive"] }
 aecir = { git = "https://github.com/nate-sys/aecir", branch = "main"}
 utf8_slice = "1.0.0"
+regex = "1.7.0"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ cargo install --git=https://github.com/nate-sys/muc
 ### Running
 
 ```sh
-muc --file $HISTFILE --count 10 --pretty                    # Bash / Zsh
-muc --file $HISTFILE --count 10 --prefix="- cmd: " --pretty # Fish
+muc --file $HISTFILE --count 10 --pretty                    # Bash
+muc --file $HISTFILE --count 10 --pretty --shell="zsh"      # Zsh
+muc --file $HISTFILE --count 10 --pretty --shell="fish"     # Fish
 
 muc --file $HISTFILE\
         --count 10\

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,4 +38,8 @@ pub struct Args {
     /// Bar character
     #[arg(long, default_value_t = '▮')]
     pub bar: char,
+
+    /// Regular expression to allow for the removal of prefixes in shells like zsh. Default value is for zsh.
+    #[arg(short, long, default_value_t = String::from(r": \d\d\d\d\d\d\d\d\d\d:\d;"))]
+    pub regexp: String,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -39,7 +39,12 @@ pub struct Args {
     #[arg(long, default_value_t = '▮')]
     pub bar: char,
 
-    /// Regular expression to allow for the removal of prefixes in shells like zsh. Default value is for zsh.
-    #[arg(short, long, default_value_t = String::from(r": \d\d\d\d\d\d\d\d\d\d:\d;"))]
+    /// Regular expression to allow for the removal of prefixes in shells like zsh. Default value is for zsh. NOTE: shell overrides this argument
+    #[arg(short, long, default_value_t = String::from(""))]
     pub regexp: String,
+
+    /// Preset regular expressions for common shells: Bash, ZSH, Fish.
+    #[arg(short, long, default_value_t = String::from(""))]
+    pub shell: String,
+
 }

--- a/src/hist_file.rs
+++ b/src/hist_file.rs
@@ -48,7 +48,14 @@ pub fn parse_contents(contents: String, args: &Args) -> HashMap<String, usize> {
         only_prefix.push_str("\n");
     }
 
-    let reg = Regex::new(&args.regexp).unwrap();
+    let regexp = match args.shell.to_lowercase().as_str() {
+        "bash" => &"",
+        "zsh" => &r": \d\d\d\d\d\d\d\d\d\d:\d;",
+        "fish" => &"- cmd: ",
+        _ => args.regexp.as_str(),
+    };
+
+    let reg = Regex::new(&regexp).unwrap();
     only_prefix = reg.replace_all(&only_prefix, "").to_string();
 
 

--- a/src/hist_file.rs
+++ b/src/hist_file.rs
@@ -48,7 +48,7 @@ pub fn parse_contents(contents: String, args: &Args) -> HashMap<String, usize> {
         only_prefix.push_str("\n");
     }
 
-    let reg = Regex::new(r": \d\d\d\d\d\d\d\d\d\d:\d;").unwrap();
+    let reg = Regex::new(&args.regexp).unwrap();
     only_prefix = reg.replace_all(&only_prefix, "").to_string();
 
 

--- a/src/hist_file.rs
+++ b/src/hist_file.rs
@@ -2,6 +2,7 @@ use crate::Args;
 use aecir::style::{Color, ColorName, Format};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
+use regex::Regex;
 
 fn print_warning(warning: &str) {
     println!(
@@ -46,6 +47,11 @@ pub fn parse_contents(contents: String, args: &Args) -> HashMap<String, usize> {
         });
         only_prefix.push_str("\n");
     }
+
+    let reg = Regex::new(r": \d\d\d\d\d\d\d\d\d\d:\d;").unwrap();
+    only_prefix = reg.replace_all(&only_prefix, "").to_string();
+
+
     let commands: Vec<&str> = only_prefix
         .split(&*separators)
         .filter(|x| !x.is_empty())


### PR DESCRIPTION
This gets rid of 0 showing up as the most common command by removing the zsh prefix with regex. I also had to add the regex dependency to the project.