### PR TITLE
Fix bug when history with no quotes were not read.

### DIFF
--- a/src/hist_file.rs
+++ b/src/hist_file.rs
@@ -66,6 +66,8 @@ fn remove_quoted_strings(contents: String, delimiter: char) -> String {
             } else {
                 slices.push(&contents[first_match+1..]);
             }
+        } else {
+            slices.push(&contents);
         }
     }
 


### PR DESCRIPTION
The bug was introduced in d2d760c. My bad.