### PR TITLE
fix extracting commands from fish history

### DIFF
--- a/src/hist_file.rs
+++ b/src/hist_file.rs
@@ -45,13 +45,9 @@ pub fn parse_contents(contents: String, args: &Args) -> Vec<String> {
         .collect();
 
     let shell_strat = match args.shell.as_str() {
-        "fish" => |line: String| -> String {
-            if line.starts_with("when: ") {
-                "".to_owned()
-            } else {
-                line[7..].to_owned()
-            }
-        },
+        "fish" => {
+            |line: String| -> String { line.strip_prefix("- cmd: ").unwrap_or("").to_owned() }
+        }
         "ohmyzsh" => |line: String| -> String { line[7..].to_owned() },
         _ => |line: String| -> String { line },
     };
@@ -80,7 +76,6 @@ pub fn parse_contents(contents: String, args: &Args) -> Vec<String> {
         .map(|line| reg.replace_all(&line, "").to_string());
     unquoted_lines.flat_map(get_commands).collect()
 }
-
 
 pub fn process_lines(lines: Vec<String>, _args: &Args) -> CommandMap {
     let leaders = ["sudo", "doas"];


### PR DESCRIPTION
fish commands start with `- cmd: ` in `fish_history` files, so we extract lines that start with that